### PR TITLE
EZAF-8759 change directory name in feast examples

### DIFF
--- a/Data-Science/Feast/definitions.py
+++ b/Data-Science/Feast/definitions.py
@@ -27,7 +27,7 @@ driver = Entity(name="driver", join_keys=["driver_id"])
 # for more info.
 driver_stats_source = FileSource(
     name="driver_hourly_stats_source",
-    path=f"{str(Path.home())}/user/Feast/data/driver_stats.parquet",
+    path=f"{str(Path.home())}/project/Feast/data/driver_stats.parquet",
     timestamp_field="event_timestamp",
     created_timestamp_column="created",
 )

--- a/Data-Science/Feast/ride-sharing-example.ipynb
+++ b/Data-Science/Feast/ride-sharing-example.ipynb
@@ -126,7 +126,7 @@
     "import pandas as pd\n",
     "from pathlib import Path\n",
     "\n",
-    "pd.read_parquet(f\"{str(Path.home())}/user/Feast/data/driver_stats.parquet\", engine=\"pyarrow\")"
+    "pd.read_parquet(f\"{str(Path.home())}/project/Feast/data/driver_stats.parquet\", engine=\"pyarrow\")"
    ]
   },
   {


### PR DESCRIPTION
Right now in feast's ride sharing use case examples we are using /user as directory. We wanted that to have a distinct name (and not /user) to make it clearer where a user works (e.g., in tutorials). At that point we decided that using the user's name instead would be better. To do so, we used /<namespace> because the namespace was same as the username. But later the namespace name changed, and we appended a random suffix. That's why we decided to use /project instead of /user. 

https://jira-pro.it.hpe.com:8443/browse/EZAF-8759