### PR TITLE
EZAF-9635 Updated Airflow examples with latest spark image tag: spark:v3.5.2.3.0

### DIFF
--- a/Data-Engineering/Airflow/example_ezaf_spark_csv_to_parquet_fts.yaml
+++ b/Data-Engineering/Airflow/example_ezaf_spark_csv_to_parquet_fts.yaml
@@ -15,7 +15,7 @@ spec:
   type: Scala
   sparkVersion: 3.5.1
   mode: cluster
-  image: '{{dag_run.conf["airgap_registry_url"]|default("lr1-bd-harbor-registry.mip.storage.hpecorp.net/develop/", True)}}hpe-spark/spark:v3.5.2.2.0'
+  image: '{{dag_run.conf["airgap_registry_url"]|default("lr1-bd-harbor-registry.mip.storage.hpecorp.net/develop/", True)}}hpe-spark/spark:v3.5.2.3.0'
   imagePullPolicy: Always
   mainApplicationFile: local:///mounts/shared-volume/shared/aie-tutorials/current-release/Data-Analytics/Spark/DataProcessTransfer/DataProcessTransfer.jar
   mainClass: com.mapr.sparkdemo.DataProcessTransfer

--- a/Data-Engineering/Airflow/example_ezaf_spark_mnist.yaml
+++ b/Data-Engineering/Airflow/example_ezaf_spark_mnist.yaml
@@ -15,7 +15,7 @@ spec:
   type: Scala
   sparkVersion: 3.5.1
   mode: cluster
-  image: '{{dag_run.conf["airgap_registry_url"]|default("lr1-bd-harbor-registry.mip.storage.hpecorp.net/develop/", True)}}hpe-spark/spark:v3.5.2.2.0'
+  image: '{{dag_run.conf["airgap_registry_url"]|default("lr1-bd-harbor-registry.mip.storage.hpecorp.net/develop/", True)}}hpe-spark/spark:v3.5.2.3.0'
   imagePullPolicy: Always
   mainApplicationFile: local:///mounts/shared-volume/shared/aie-tutorials/current-release/Data-Analytics/Spark/DataTransfer/DataTransfer.jar
   mainClass: com.mapr.sparkdemo.DataTransfer

--- a/Data-Engineering/Airflow/example_spark_pi.yaml
+++ b/Data-Engineering/Airflow/example_spark_pi.yaml
@@ -6,7 +6,7 @@ spec:
   type: Scala
   sparkVersion: 3.5.1
   mode: cluster
-  image: '{{dag_run.conf["airgap_registry_url"]|default("lr1-bd-harbor-registry.mip.storage.hpecorp.net/develop/", True)}}hpe-spark/spark:v3.5.2.2.0'
+  image: '{{dag_run.conf["airgap_registry_url"]|default("lr1-bd-harbor-registry.mip.storage.hpecorp.net/develop/", True)}}hpe-spark/spark:v3.5.2.3.0'
   imagePullPolicy: Always
   imagePullSecrets:
   - imagepull


### PR DESCRIPTION
- Updated Spark image in Airflow examples from `spark:v3.5.2.2.0` to `spark:v3.5.2.3.0`
- Attached screenshots to validate and verify the changes across DAG runs and pod details.
- Jira : https://jira-pro.it.hpe.com:8443/browse/EZAF-9635
<img width="1483" alt="Screenshot 2025-04-16 at 7 29 38 PM" src="https://github.com/user-attachments/assets/3d13a088-6211-44dc-b27a-01630fd45361" />
<img width="1482" alt="Screenshot 2025-04-16 at 7 30 01 PM" src="https://github.com/user-attachments/assets/292ee04c-a531-4102-977e-c080ff699c0f" />
<img width="1481" alt="Screenshot 2025-04-16 at 7 30 18 PM" src="https://github.com/user-attachments/assets/24a25891-4bec-45c8-92f2-e7b4b4273757" />
