### PR TITLE
PCCM-116507 update registry URL input

### DIFF
--- a/Data-Engineering/Airflow/example_ezaf_spark_csv_to_parquet_fts.py
+++ b/Data-Engineering/Airflow/example_ezaf_spark_csv_to_parquet_fts.py
@@ -1,3 +1,4 @@
+import os
 from airflow import DAG
 from airflow.models.param import Param
 from airflow.providers.cncf.kubernetes.operators.spark_kubernetes import (

--- a/Data-Engineering/Airflow/example_ezaf_spark_csv_to_parquet_fts.py
+++ b/Data-Engineering/Airflow/example_ezaf_spark_csv_to_parquet_fts.py
@@ -46,11 +46,11 @@ dag = DAG(
             type="string",
             description="S3 key to pull csv data from",
         ),
-        "airgap_registry_url": Param(
-            "",
-            type=["null", "string"],
-            pattern=r"^$|^\S+/$",
-            description="Airgap registry url. Trailing slash in the end is required",
+        "registry_url": Param(
+            os.environ.get("AIRGAP_REGISTRY"),
+            type=["string"],
+            pattern=r"^\S+/$",
+            description="Input your registry url. Trailing slash in the end is required",
         ),
     },
     render_template_as_native_obj=True,

--- a/Data-Engineering/Airflow/example_ezaf_spark_csv_to_parquet_fts.yaml
+++ b/Data-Engineering/Airflow/example_ezaf_spark_csv_to_parquet_fts.yaml
@@ -15,7 +15,7 @@ spec:
   type: Scala
   sparkVersion: 3.5.1
   mode: cluster
-  image: '{{dag_run.conf["airgap_registry_url"]|default("lr1-bd-harbor-registry.mip.storage.hpecorp.net/develop/", True)}}hpe-spark/spark:v3.5.2.3.0'
+  image: '{{dag_run.conf["registry_url"]}}hpe-spark/spark:v3.5.2.3.0'
   imagePullPolicy: Always
   mainApplicationFile: local:///mounts/shared-volume/shared/aie-tutorials/current-release/Data-Analytics/Spark/DataProcessTransfer/DataProcessTransfer.jar
   mainClass: com.mapr.sparkdemo.DataProcessTransfer

--- a/Data-Engineering/Airflow/example_ezaf_spark_mnist.py
+++ b/Data-Engineering/Airflow/example_ezaf_spark_mnist.py
@@ -1,3 +1,4 @@
+import os
 from airflow import DAG
 from airflow.models.param import Param
 from airflow.providers.cncf.kubernetes.operators.spark_kubernetes import (

--- a/Data-Engineering/Airflow/example_ezaf_spark_mnist.py
+++ b/Data-Engineering/Airflow/example_ezaf_spark_mnist.py
@@ -46,11 +46,11 @@ dag = DAG(
             type="string",
             description="S3 key to pull binary data from",
         ),
-        "airgap_registry_url": Param(
-            "",
-            type=["null", "string"],
-            pattern=r"^$|^\S+/$",
-            description="Airgap registry url. Trailing slash in the end is required",
+        "registry_url": Param(
+            os.environ.get("AIRGAP_REGISTRY"),
+            type=["string"],
+            pattern=r"^\S+/$",
+            description="Input your registry url. Trailing slash in the end is required",
         ),
     },
     render_template_as_native_obj=True,

--- a/Data-Engineering/Airflow/example_ezaf_spark_mnist.yaml
+++ b/Data-Engineering/Airflow/example_ezaf_spark_mnist.yaml
@@ -15,7 +15,7 @@ spec:
   type: Scala
   sparkVersion: 3.5.1
   mode: cluster
-  image: '{{dag_run.conf["airgap_registry_url"]|default("lr1-bd-harbor-registry.mip.storage.hpecorp.net/develop/", True)}}hpe-spark/spark:v3.5.2.3.0'
+  image: '{{dag_run.conf["registry_url"]}}hpe-spark/spark:v3.5.2.3.0'
   imagePullPolicy: Always
   mainApplicationFile: local:///mounts/shared-volume/shared/aie-tutorials/current-release/Data-Analytics/Spark/DataTransfer/DataTransfer.jar
   mainClass: com.mapr.sparkdemo.DataTransfer

--- a/Data-Engineering/Airflow/example_spark_pi.py
+++ b/Data-Engineering/Airflow/example_spark_pi.py
@@ -1,3 +1,4 @@
+import os
 from airflow import DAG
 from airflow.models.param import Param
 from airflow.providers.cncf.kubernetes.operators.spark_kubernetes import (
@@ -25,11 +26,11 @@ dag = DAG(
     schedule_interval=None,
     tags=["ezaf", "spark", "pi"],
     params={
-        "airgap_registry_url": Param(
-            "",
-            type=["null", "string"],
-            pattern=r"^$|^\S+/$",
-            description="Airgap registry url. Trailing slash in the end is required",
+        "registry_url": Param(
+            os.environ.get("AIRGAP_REGISTRY"),
+            type=["string"],
+            pattern=r"^\S+/$",
+            description="Input your registry url. Trailing slash in the end is required",
         ),
     },
     render_template_as_native_obj=True,

--- a/Data-Engineering/Airflow/example_spark_pi.yaml
+++ b/Data-Engineering/Airflow/example_spark_pi.yaml
@@ -6,7 +6,7 @@ spec:
   type: Scala
   sparkVersion: 3.5.1
   mode: cluster
-  image: '{{dag_run.conf["airgap_registry_url"]|default("lr1-bd-harbor-registry.mip.storage.hpecorp.net/develop/", True)}}hpe-spark/spark:v3.5.2.3.0'
+  image: '{{dag_run.conf["registry_url"]}}hpe-spark/spark:v3.5.2.3.0'
   imagePullPolicy: Always
   imagePullSecrets:
   - imagepull


### PR DESCRIPTION
**JIRA:**https://hpe.atlassian.net/browse/PCCM-116507

**Changes:** Removed the default registry from the YAML file. The updated implementation now retrieves the registry URL from the environment variable and automatically populates it in the UI.

**Result:** Users can trigger the DAG directly without needing to modify or manually enter the registry URL.
**Tests:**
<img width="1714" alt="image" src="https://github.com/user-attachments/assets/3e546a8c-1bd5-4955-8c71-b46b77174516" />

sucess 
<img width="1712" alt="image" src="https://github.com/user-attachments/assets/46b24752-f1f0-4ffd-9b64-c7fec1661ea5" />


