### PR TITLE
EZAF-9702 update gcr repo and spark images to latest version

### DIFF
--- a/Data-Engineering/Airflow/example_ezaf_spark_csv_to_parquet_fts.yaml
+++ b/Data-Engineering/Airflow/example_ezaf_spark_csv_to_parquet_fts.yaml
@@ -15,7 +15,7 @@ spec:
   type: Scala
   sparkVersion: 3.5.1
   mode: cluster
-  image: '{{dag_run.conf["registry_url"]}}hpe-spark/spark:v3.5.2.3.0'
+  image: '{{dag_run.conf["registry_url"]}}hpe-spark/spark:v3.5.5.2.0'
   imagePullPolicy: Always
   mainApplicationFile: local:///mounts/shared-volume/shared/aie-tutorials/current-release/Data-Analytics/Spark/DataProcessTransfer/DataProcessTransfer.jar
   mainClass: com.mapr.sparkdemo.DataProcessTransfer

--- a/Data-Engineering/Airflow/example_ezaf_spark_mnist.yaml
+++ b/Data-Engineering/Airflow/example_ezaf_spark_mnist.yaml
@@ -15,7 +15,7 @@ spec:
   type: Scala
   sparkVersion: 3.5.1
   mode: cluster
-  image: '{{dag_run.conf["registry_url"]}}hpe-spark/spark:v3.5.2.3.0'
+  image: '{{dag_run.conf["registry_url"]}}hpe-spark/spark:v3.5.5.2.0'
   imagePullPolicy: Always
   mainApplicationFile: local:///mounts/shared-volume/shared/aie-tutorials/current-release/Data-Analytics/Spark/DataTransfer/DataTransfer.jar
   mainClass: com.mapr.sparkdemo.DataTransfer

--- a/Data-Engineering/Airflow/example_spark_pi.yaml
+++ b/Data-Engineering/Airflow/example_spark_pi.yaml
@@ -6,7 +6,7 @@ spec:
   type: Scala
   sparkVersion: 3.5.1
   mode: cluster
-  image: '{{dag_run.conf["registry_url"]}}hpe-spark/spark:v3.5.2.3.0'
+  image: '{{dag_run.conf["registry_url"]}}hpe-spark/spark:v3.5.5.2.0'
   imagePullPolicy: Always
   imagePullSecrets:
   - imagepull

--- a/Data-Engineering/Airflow/example_spark_pi_oss.py
+++ b/Data-Engineering/Airflow/example_spark_pi_oss.py
@@ -1,3 +1,4 @@
+import os
 from airflow import DAG
 from airflow.models.param import Param
 from airflow.providers.cncf.kubernetes.operators.spark_kubernetes import (

--- a/Data-Engineering/Airflow/example_spark_pi_oss.py
+++ b/Data-Engineering/Airflow/example_spark_pi_oss.py
@@ -32,7 +32,7 @@ dag = DAG(
             description="Provide Python-Spark image url",
         ),
         "spark_image_version": Param(
-            "3.5.2",
+            "3.5.5",
             type=["null", "string"],
             description="Provide Spark image Version",
         )

--- a/Data-Engineering/Airflow/example_spark_pi_oss.py
+++ b/Data-Engineering/Airflow/example_spark_pi_oss.py
@@ -27,7 +27,7 @@ dag = DAG(
     tags=["ezaf", "spark", "pi"],
     params={
         "spark_image_url": Param(
-           f"{os.environ.get('AIRGAP_REGISTRY')}/hpe-spark/apache-spark:v3.5.5",
+           f"{os.environ.get('AIRGAP_REGISTRY')}hpe-spark/apache-spark:v3.5.5",
             type=["string"],
             description="Provide Python-Spark image url",
         ),

--- a/Data-Engineering/Airflow/example_spark_pi_oss.py
+++ b/Data-Engineering/Airflow/example_spark_pi_oss.py
@@ -26,8 +26,8 @@ dag = DAG(
     tags=["ezaf", "spark", "pi"],
     params={
         "spark_image_url": Param(
-            "gcr.io/mapr-252711/apache-spark:3.5.2",
-            type=["null", "string"],
+           f"{os.environ.get('AIRGAP_REGISTRY')}/hpe-spark/apache-spark:v3.5.5",
+            type=["string"],
             description="Provide Python-Spark image url",
         ),
         "spark_image_version": Param(

--- a/Data-Engineering/Airflow/example_spark_pi_oss.yaml
+++ b/Data-Engineering/Airflow/example_spark_pi_oss.yaml
@@ -6,7 +6,7 @@ spec:
   type: Python
   sparkVersion: '{{dag_run.conf["spark_image_version"]}}'
   mode: cluster
-  image: '{{dag_run.conf["spark_image_url"]}}hpe-spark/apache-spark:v3.5.5'
+  image: '{{dag_run.conf["spark_image_url"]}}'
   imagePullPolicy: Always
   imagePullSecrets:
   - imagepull

--- a/Data-Engineering/Airflow/example_spark_pi_oss.yaml
+++ b/Data-Engineering/Airflow/example_spark_pi_oss.yaml
@@ -6,7 +6,7 @@ spec:
   type: Python
   sparkVersion: '{{dag_run.conf["spark_image_version"]}}'
   mode: cluster
-  image: '{{dag_run.conf["registry_url"]}}hpe-spark/apache-spark:v3.5.5'
+  image: '{{dag_run.conf["spark_image_url"]}}hpe-spark/apache-spark:v3.5.5'
   imagePullPolicy: Always
   imagePullSecrets:
   - imagepull

--- a/Data-Engineering/Airflow/example_spark_pi_oss.yaml
+++ b/Data-Engineering/Airflow/example_spark_pi_oss.yaml
@@ -6,7 +6,7 @@ spec:
   type: Python
   sparkVersion: '{{dag_run.conf["spark_image_version"]}}'
   mode: cluster
-  image: '{{dag_run.conf["spark_image_url"]|default("", True)}}'
+  image: '{{dag_run.conf["registry_url"]}}hpe-spark/apache-spark:v3.5.5'
   imagePullPolicy: Always
   imagePullSecrets:
   - imagepull


### PR DESCRIPTION
Updated the OSS Spark image to use Harbor instead of GCR, and also upgraded the images to the latest versions.

**Latest OSS version:** lr1-bd-harbor-registry.mip.storage.hpecorp.net/develop/hpe-spark/apache-spark:v3.5.5
**Latest eep spark version:** lr1-bd-harbor-registry.mip.storage.hpecorp.net/develop/hpe-spark/spark:v3.5.5.2.0