### PR TITLE
Fix wordcount example image to be marketplace location

### DIFF
--- a/Data-Analytics/Spark/wordcount/wordcount.yaml
+++ b/Data-Analytics/Spark/wordcount/wordcount.yaml
@@ -7,7 +7,7 @@ spec:
   type: Python
   sparkVersion: 3.5.2
   mode: cluster
-  image: lr1-bd-harbor-registry.mip.storage.hpecorp.net/develop/hpe-spark/spark:v3.5.2.3.0
+  image: marketplace.us1.greenlake-hpe.com/ezmeral-common/hpe-spark/spark:v3.5.2.3.0
   imagePullPolicy: Always
   mainApplicationFile: "local:///mounts/shared-volume/shared/aie-tutorials/current-release/Data-Analytics/Spark/wordcount/wordcount.py"
   arguments:


### PR DESCRIPTION
As published, the example tried to pill the image from our LR1 artifactory which is inaccessible to anyone outside an AIE dev environment. Updated to marketplace.us1.greenlake-hpe.com/ezmeral-common/hpe-spark/spark:v3.5.2.3.0