### PR TITLE
EZAF-11678: Removing installation of mlflow[auth], seaborn and update_token magic

### DIFF
--- a/Data-Science/MLflow/bike-sharing-mlflow.ipynb
+++ b/Data-Science/MLflow/bike-sharing-mlflow.ipynb
@@ -869,16 +869,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#!pip3 install --proxy <PROXY> mlflow[auth]\n",
-    "!pip3 install mlflow[auth]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "from mlflow.server.auth.client import AuthServiceClient\n",
     "\n",
     "user = #\" USERNAME\"\n",

--- a/Data-Science/MLflow/bike-sharing-mlflow.ipynb
+++ b/Data-Science/MLflow/bike-sharing-mlflow.ipynb
@@ -57,8 +57,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#!pip3 install --proxy <PROXY> pydotplus graphviz seaborn\n",
-    "!pip3 install pydotplus graphviz seaborn"
+    "#!pip3 install --proxy <PROXY> pydotplus graphviz\n",
+    "!pip3 install pydotplus graphviz"
    ]
   },
   {

--- a/Data-Science/MLflow/bike-sharing-prediction.ipynb
+++ b/Data-Science/MLflow/bike-sharing-prediction.ipynb
@@ -107,7 +107,6 @@
     "  ]\n",
     "}\n",
     "\n",
-    "%update_token\n",
     "\n",
     "headers = {\"Authorization\": f\"Bearer {os.environ['AUTH_TOKEN']}\"}\n",
     "\n",


### PR DESCRIPTION
mlflow[auth] requires Flask-WTF<2. Adding this package in base jupyter notebook eliminates the requirement for installing it separately.

Removed `%update_token` magic as s3-credential-process is injecting it as AWS_CONFIG_FILE through Kyverno. Therefore, using magic is not necessary.

Removing seaborn package install, as its present in all NBs. 
 https://github.com/mlflow/mlflow/blob/v2.22.0/pyproject.toml#L114