### PR TITLE
EZAF-12911: Update kfp.dsl.component base Images to aie-1.11.0

### DIFF
--- a/Data-Science/Kubeflow/MNIST-Digits-Recognition/mnist_katib_tf_kserve_example.ipynb
+++ b/Data-Science/Kubeflow/MNIST-Digits-Recognition/mnist_katib_tf_kserve_example.ipynb
@@ -399,7 +399,7 @@
     "# This function converts Katib Experiment HP results to args.\n",
     "\n",
     "from kfp import components\n",
-    "@dsl.component(base_image = f\"{airgap_registry}hpe-kubeflow/python-kfp:aie-1.10.0-ff81138\")\n",
+    "@dsl.component(base_image = f\"{airgap_registry}hpe-kubeflow/python-kfp:aie-1.11.0-0829432a\")\n",
     "def convert_katib_results(katib_results: dict) -> str:\n",
     "    import json\n",
     "    import pprint\n",


### PR DESCRIPTION
AIE 1.11 has upgrade Kubeflow which has KFP=2.11.0, therefore, kfp.dsl.component base image which has python (3.13.3)  and kfp (2.11.0) is updated.