### PR TITLE
EZAF-12952: Adding scikit-learn package

### DIFF
--- a/Data-Science/MLflow/bike-sharing-mlflow.ipynb
+++ b/Data-Science/MLflow/bike-sharing-mlflow.ipynb
@@ -73,7 +73,7 @@
    "outputs": [],
    "source": [
     "#!pip3 install --proxy <PROXY> pydotplus graphviz\n",
-    "!pip3 install pydotplus graphviz"
+    "!pip3 install pydotplus graphviz scikit-learn==1.4.2"
    ]
   },
   {

--- a/Data-Science/MLflow/bike-sharing-prediction.ipynb
+++ b/Data-Science/MLflow/bike-sharing-prediction.ipynb
@@ -107,7 +107,7 @@
     "  ]\n",
     "}\n",
     "\n",
-    "%update_token\n",
+    "\n",
     "headers = {\"Authorization\": f\"Bearer {os.environ['AUTH_TOKEN']}\"}\n",
     "\n",
     "response = requests.post(URL, json=inputs, headers=headers, verify=VERIFY)\n",

--- a/Data-Science/MLflow/bike-sharing-prediction.ipynb
+++ b/Data-Science/MLflow/bike-sharing-prediction.ipynb
@@ -107,7 +107,7 @@
     "  ]\n",
     "}\n",
     "\n",
-    "\n",
+    "%update_token\n",
     "headers = {\"Authorization\": f\"Bearer {os.environ['AUTH_TOKEN']}\"}\n",
     "\n",
     "response = requests.post(URL, json=inputs, headers=headers, verify=VERIFY)\n",


### PR DESCRIPTION
https://jira-pro.it.hpe.com:8443/browse/EZAF-12952
Installing `scikit-learn==1.4.2` separately as mlflow and NBs (Except Data Science NB) are having `scikit-learn>=1.6.1` however, with `scikit-learn==1.6.1` version mlflow.sklearn is failing with below error while loading model. _mlflow.sklearn.load_model_

`AttributeError: Can't get attribute '__pyx_unpickle_CyHalfSquaredError' on <module 'sklearn._loss._loss' from '[/opt/conda/lib/python3.11/site-packages/sklearn/_loss/_loss.cpython-311-x86_64-linux-gnu.so](https://kubeflow.apps-kubeflow-cluster01.hpepcai.com/opt/conda/lib/python3.11/site-packages/sklearn/_loss/_loss.cpython-311-x86_64-linux-gnu.so)'>`
