### PR TITLE
AISW-19679: Updating the memory limits for spark yaml

### DIFF
--- a/Data-Analytics/Spark/DataProcessTransfer/DataProcessTransferFts.yaml
+++ b/Data-Analytics/Spark/DataProcessTransfer/DataProcessTransferFts.yaml
@@ -31,7 +31,7 @@ spec:
       version: 3.5.5
     cores: 1
     coreLimit: "1"
-    memory: 512m    
+    memory: 1g
   executor:
     labels:
       version: 3.5.5

--- a/Data-Analytics/Spark/DataTransfer/DataTransferMnist.yaml
+++ b/Data-Analytics/Spark/DataTransfer/DataTransferMnist.yaml
@@ -31,7 +31,7 @@ spec:
       version: 3.5.5
     cores: 1
     coreLimit: "1"
-    memory: 512m    
+    memory: 1g
   executor:
     labels:
       version: 3.5.5

--- a/Data-Engineering/Airflow/example_ezaf_spark_csv_to_parquet_fts.yaml
+++ b/Data-Engineering/Airflow/example_ezaf_spark_csv_to_parquet_fts.yaml
@@ -29,7 +29,7 @@ spec:
   driver:
     cores: 1
     coreLimit: "1000m"
-    memory: "512m"
+    memory: "1Gi"
     labels:
       version: 3.5.5
     volumeMounts:

--- a/Data-Engineering/Airflow/example_ezaf_spark_csv_to_parquet_fts.yaml
+++ b/Data-Engineering/Airflow/example_ezaf_spark_csv_to_parquet_fts.yaml
@@ -29,7 +29,7 @@ spec:
   driver:
     cores: 1
     coreLimit: "1000m"
-    memory: "1Gi"
+    memory: "1g"
     labels:
       version: 3.5.5
     volumeMounts:

--- a/Data-Engineering/Airflow/example_ezaf_spark_mnist.yaml
+++ b/Data-Engineering/Airflow/example_ezaf_spark_mnist.yaml
@@ -29,7 +29,7 @@ spec:
   driver:
     cores: 1
     coreLimit: "1000m"
-    memory: "512m"
+    memory: "1Gi"
     labels:
       version: 3.5.5
     volumeMounts:

--- a/Data-Engineering/Airflow/example_ezaf_spark_mnist.yaml
+++ b/Data-Engineering/Airflow/example_ezaf_spark_mnist.yaml
@@ -29,7 +29,7 @@ spec:
   driver:
     cores: 1
     coreLimit: "1000m"
-    memory: "1Gi"
+    memory: "1g"
     labels:
       version: 3.5.5
     volumeMounts:


### PR DESCRIPTION
Link to [AISW-19679](https://hpe.atlassian.net/browse/AISW-19679)

The `spark-mnist` and `spark-fts` applications were failing at the driver pod with the default 512m memory limit but ran successfully with increased memory (900m). Other clusters (Rocky/RHEL-based LR1, G2 Medium, and Ubuntu LR5) worked fine with the default configuration. However, on the affected Ubuntu-based cluster, the issue appears to be resource-related.
To ensure consistent execution across environments, the driver pod memory limit has been updated to 1g.