### PR TITLE
Update .airflowignore to fix issue with ignoring OSS folder

### DIFF
--- a/Data-Engineering/Airflow/.airflowignore
+++ b/Data-Engineering/Airflow/.airflowignore
@@ -1,3 +1,3 @@
 # Ignore OSS DAGs by default. To see them, explicitly specify 'Data-Engineering/Airflow/OSS' as subDir 
 # in Airflow configuration or edit this file to remove the line below.
-OSS/
+OSS/*


### PR DESCRIPTION
The issue was introduced in OSS here: `https://github.com/apache/airflow/issues/56126`. Despite being closed in OSS, it seems it still exists