### PR TITLE
Update alpine image in Airflow DAG to be in sync with AIE

### DIFF
--- a/Data-Engineering/Airflow/example_kubernetes_operator.py
+++ b/Data-Engineering/Airflow/example_kubernetes_operator.py
@@ -25,7 +25,7 @@ from airflow.sdk import dag, task
                 description="Input your registry url. Trailing slash in the end is required",
             ),
             "container_image": Param(
-                "docker.io/alpine:3.22",
+                "aie-vnd/alpine:3.23-202603261456",
                 type="string",
                 description="Container image to run inside Kubernetes Pod",
             ),


### PR DESCRIPTION
Since we are using our own image in AIE instead of OSS `docker.io/alpine:3.22`, here in this DAG we need to update the default value of alpine image input: `aie-vnd/alpine:3.23-202603261456` - we are now using such an AIE vendored image for alpine